### PR TITLE
Streaming API

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,10 +20,12 @@
     "rimraf": "~2.1.4",
     "fstream": "~0.1.22",
     "tar": "~0.1.17",
-    "fstream-ignore": "0.0.6"
+    "fstream-ignore": "0.0.6",
+    "readable-stream": "~1.0.2"
   },
   "devDependencies": {
     "mocha": "~1.9.0",
-    "rfile": "~1.0.0"
+    "rfile": "~1.0.0",
+    "mkdirp": "~0.3.5"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -1,55 +1,67 @@
 var tar = require('../')
 var path = require('path')
 var rfile = require('rfile')
-var rimraf = require('rimraf').sync;
+var rimraf = require('rimraf').sync
+var mkdir = require('mkdirp').sync
 
+var read = require('fs').createReadStream
+var write = require('fs').createWriteStream
 var assert = require('assert')
 
 beforeEach(function () {
-  rimraf(__dirname + '/output');
+  rimraf(__dirname + '/output')
 })
 afterEach(function () {
-  rimraf(__dirname + '/output');
+  rimraf(__dirname + '/output')
 })
-describe('unpack(tarball, directory, callback', function () {
+describe('tarball.pipe(unpack(directory, callback))', function () {
   it('unpacks the tarball into the directory', function (done) {
-    tar.unpack(__dirname + '/fixtures/packed.tar', __dirname + '/output/unpacked', function (err) {
+    read(__dirname + '/fixtures/packed.tar').pipe(tar.unpack(__dirname + '/output/unpacked', function (err) {
       if (err) return done(err)
       assert.equal(rfile('./output/unpacked/bar.txt'), rfile('./fixtures/to-pack/bar.txt'))
       assert.equal(rfile('./output/unpacked/foo.txt'), rfile('./fixtures/to-pack/foo.txt'))
       done()
-    })
+    }))
   })
 })
-describe('unpack(gziptarball, directory, callback', function () {
+describe('gziptarball.pipe(unpack(directory, callback))', function () {
   it('unpacks the tarball into the directory', function (done) {
-    tar.unpack(__dirname + '/fixtures/packed-file.txt', __dirname + '/output/unpacked', function (err) {
+    read(__dirname + '/fixtures/packed.tar.gz').pipe(tar.unpack(__dirname + '/output/unpacked', function (err) {
+      if (err) return done(err)
+      assert.equal(rfile('./output/unpacked/bar.txt'), rfile('./fixtures/to-pack/bar.txt'))
+      assert.equal(rfile('./output/unpacked/foo.txt'), rfile('./fixtures/to-pack/foo.txt'))
+      done()
+    }))
+  })
+})
+describe('file.pipe(unpack(directory, callback))', function () {
+  it('copies the file into the directory', function (done) {
+    read(__dirname + '/fixtures/packed-file.txt').pipe(tar.unpack(__dirname + '/output/unpacked', function (err) {
       if (err) return done(err)
       assert.equal(rfile('./output/unpacked/index.js'), rfile('./fixtures/packed-file.txt'))
       done()
-    })
+    }))
   })
 })
-describe('unpack(file, directory, callback', function () {
-  it('copies the file into the directory', function (done) {
-    tar.unpack(__dirname + '/fixtures/packed.tar.gz', __dirname + '/output/unpacked', function (err) {
-      if (err) return done(err)
-      assert.equal(rfile('./output/unpacked/bar.txt'), rfile('./fixtures/to-pack/bar.txt'))
-      assert.equal(rfile('./output/unpacked/foo.txt'), rfile('./fixtures/to-pack/foo.txt'))
-      done()
-    })
-  })
-})
-describe('pack(directory, tarball, callback', function () {
+describe('pack(directory).pipe(tarball)', function () {
   it('packs the directory into the output', function (done) {
-    tar.pack(__dirname + '/fixtures/to-pack', __dirname + '/output/packed.tar.gz', function (err) {
-      if (err) return done(err)
-      tar.unpack(__dirname + '/output/packed.tar.gz', __dirname + '/output/unpacked', function (err) {
-        if (err) return done(err)
-        assert.equal(rfile('./output/unpacked/bar.txt'), rfile('./fixtures/to-pack/bar.txt'))
-        assert.equal(rfile('./output/unpacked/foo.txt'), rfile('./fixtures/to-pack/foo.txt'))
-        done()
+    var called = false
+    mkdir(__dirname + '/output/')
+    tar.pack(__dirname + '/fixtures/to-pack').pipe(write(__dirname + '/output/packed.tar.gz'))
+      .on('error', function (err) {
+        if (called) return
+        called = true
+        done(err)
       })
-    })
+      .on('close', function () {
+        if (called) return
+        called = true
+        read(__dirname + '/output/packed.tar.gz').pipe(tar.unpack(__dirname + '/output/unpacked', function (err) {
+          if (err) return done(err)
+          assert.equal(rfile('./output/unpacked/bar.txt'), rfile('./fixtures/to-pack/bar.txt'))
+          assert.equal(rfile('./output/unpacked/foo.txt'), rfile('./fixtures/to-pack/foo.txt'))
+          done()
+        }))
+      })
   })
 })


### PR DESCRIPTION
This completely changes the API to be streaming rather than take a file name for the tar side.

It doesn't make sense to change the other side to be "pipeable" because there isn't actually a standard representation for a "directory" stream.

I'll wait for someone to review this.

/cc @robertkowalski @jkroso
