### PR TITLE
Update Travis CI settings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
+sudo: false
 language: node_js
 node_js:
-  - "0.8"
+  - stable
   - "0.10"
+  - "0.8"
+before_install: if [[ `npm --version` != 3* ]]; then npm install -g npm; fi;


### PR DESCRIPTION
* Use [container-based infrastructure](http://docs.travis-ci.com/user/workers/container-based-infrastructure/) by adding `sudo: false` for faster build
* [Test on the latest stable Node](https://github.com/ForbesLindesay/tar-pack/blob/40be47aef4300deddf30841265e5a8203d419982/.travis.yml#L4)
* Update npm if an older version is installed
  * The only problem in [this error](https://github.com/ForbesLindesay/tar-pack/pull/7#issuecomment-153294972) is that npm v1.2 doesn't support the `^` version specifier. It's not the problem of Node v0.8 itself.
So I added [`before_install` command](https://github.com/ForbesLindesay/tar-pack/blob/40be47aef4300deddf30841265e5a8203d419982/.travis.yml#L7) to install the latest version of npm, before installing the dependencies of tar-pack.
