### PR TITLE
Update fstream & tar dependencies to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
     "once": "~1.1.1",
     "debug": "~0.7.2",
     "rimraf": "~2.2.0",
-    "fstream": "~0.1.22",
+    "fstream": "~1.0.8",
     "tar": "~2.2.1",
-    "fstream-ignore": "0.0.7",
+    "fstream-ignore": "~1.0.3",
     "readable-stream": "~1.0.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Resolves #9

Tests continue to pass locally with the updates