### PR TITLE
Optional delete files when unpacking

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Advanced Options (you probably don't need any of these):
  - `fmode` - (defaults to `0666`) The mode to use when creating files
  - `unsafe` - (defaults to `false`) (on non win32 OSes it overrides `gid` and `uid` with the current processes IDs)
  - `strip` - (defaults to `1`) Number of path segments to strip from the root when extracting
+ - `keepFiles` - (defaults to `false`) Set this to `true` to prevent target directory to be removed. Extracted files overwrite existing files.
 
 Example:
 

--- a/index.js
+++ b/index.js
@@ -109,13 +109,17 @@ function unpack(unpackTarget, options, cb) {
     }
     if (0 === --pending) next()
   })
-  rm(unpackTarget, function (er) {
-    if (er) {
-      tarball.emit('error', er)
-      return tarball.end()
-    }
-    if (0 === --pending) next()
-  })
+  if (!options.keepFiles) {
+    rm(unpackTarget, function (er) {
+      if (er) {
+        tarball.emit('error', er)
+        return tarball.end()
+      }
+      if (0 === --pending) next()
+    })
+  } else {
+    next()
+  }
   function next() {
     // gzip {tarball} --decompress --stdout \
     //   | tar -mvxpf - --strip-components={strip} -C {unpackTarget}

--- a/test/index.js
+++ b/test/index.js
@@ -23,6 +23,16 @@ describe('tarball.pipe(unpack(directory, callback))', function () {
       done()
     }))
   })
+  it('unpacks the tarball into the directory without deleting existing files', function (done) {
+    read(__dirname + '/fixtures/packed-file.txt').pipe(tar.unpack(__dirname + '/output/unpacked', function (err) {
+      if (err) return done(err)
+      read(__dirname + '/fixtures/packed.tar').pipe(tar.unpack(__dirname + '/output/unpacked', {keepFiles: true}, function (err) {
+        if (err) return done(err)
+        assert.equal(rfile('./output/unpacked/index.js'), rfile('./fixtures/packed-file.txt'))
+        done()
+      }))
+    }))
+  })
 })
 describe('tarball.pipe(unpack(directory, { strip: 0 }, callback))', function () {
   it('unpacks the tarball into the directory with subdir package', function (done) {


### PR DESCRIPTION
Currently the unpack always deletes the target directory. This PR adds an option to allow keeping the previous directory contents.