### PR TITLE
added fromBase option to pack

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ pack(require("fstream-npm")(folder), [options])
 Options:
 
  - `noProprietary` (defaults to `false`) Set this to `true` to prevent any proprietary attributes being added to the tarball.  These attributes are allowed by the spec, but may trip up some poorly written tarball parsers.
+ - `fromBase` (defaults to `false`) Set this to `true` to make sure your tarballs root is the directory you pass in.
  - `ignoreFiles` (defaults to `['.gitignore']`) These files can specify files to be excluded from the package using the syntax of `.gitignore`.  This option is ignored if you parse a `fstream.DirReader` instead of a string for folder.
  - `filter` (defaults to `entry => true`) A function that takes an entry and returns `true` if it should be included in the package and `false` if it should not.  Entryies are of the form `{path, basename, dirname, type}` where (type is "Directory" or "File").  This function is ignored if you parse a `fstream.DirReader` instead of a string for folder.
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Advanced Options (you probably don't need any of these):
  - `dmode` - (defaults to `0777`) The mode to use when creating directories
  - `fmode` - (defaults to `0666`) The mode to use when creating files
  - `unsafe` - (defaults to `false`) (on non win32 OSes it overrides `gid` and `uid` with the current processes IDs)
+ - `strip` - (defaults to `1`) Number of path segments to strip from the root when extracting
 
 Example:
 

--- a/index.js
+++ b/index.js
@@ -55,7 +55,7 @@ function pack(folder, options) {
   // However, npm *itself* excludes these from its own package,
   // so that it can be more easily bootstrapped using old and
   // non-compliant tar implementations.
-  var tarPack = tar.Pack({ noProprietary: options.noProprietary || false })
+  var tarPack = tar.Pack({ noProprietary: options.noProprietary || false, fromBase: options.fromBase || false })
   var gzip = zlib.Gzip()
 
   folder

--- a/index.js
+++ b/index.js
@@ -92,6 +92,7 @@ function unpack(unpackTarget, options, cb) {
   var dMode = options.dmode || 0x0777 //npm.modes.exec
   var fMode = options.fmode || 0x0666 //npm.modes.file
   var defaultName = options.defaultName || (options.defaultName === false ? false : 'index.js')
+  var strip = (options.strip !== undefined) ? options.strip : 1
 
   // figure out who we're supposed to be, if we're not pretending
   // to be a specific user.
@@ -117,14 +118,14 @@ function unpack(unpackTarget, options, cb) {
   })
   function next() {
     // gzip {tarball} --decompress --stdout \
-    //   | tar -mvxpf - --strip-components=1 -C {unpackTarget}
-    gunzTarPerm(tarball, unpackTarget, dMode, fMode, uid, gid, defaultName)
+    //   | tar -mvxpf - --strip-components={strip} -C {unpackTarget}
+    gunzTarPerm(tarball, unpackTarget, dMode, fMode, uid, gid, defaultName, strip)
   }
   return tarball
 }
 
 
-function gunzTarPerm(tarball, target, dMode, fMode, uid, gid, defaultName) {
+function gunzTarPerm(tarball, target, dMode, fMode, uid, gid, defaultName, strip) {
   debug('modes %j', [dMode.toString(8), fMode.toString(8)])
 
   function fixEntry(entry) {
@@ -145,7 +146,7 @@ function gunzTarPerm(tarball, target, dMode, fMode, uid, gid, defaultName) {
     }
   }
 
-  var extractOpts = { type: 'Directory', path: target, strip: 1 }
+  var extractOpts = { type: 'Directory', path: target, strip: strip }
 
   if (!win32 && typeof uid === 'number' && typeof gid === 'number') {
     extractOpts.uid = uid

--- a/test/index.js
+++ b/test/index.js
@@ -24,6 +24,16 @@ describe('tarball.pipe(unpack(directory, callback))', function () {
     }))
   })
 })
+describe('tarball.pipe(unpack(directory, { strip: 0 }, callback))', function () {
+  it('unpacks the tarball into the directory with subdir package', function (done) {
+    read(__dirname + '/fixtures/packed.tar').pipe(tar.unpack(__dirname + '/output/unpacked', { strip: 0 } , function (err) {
+      if (err) return done(err)
+      assert.equal(rfile('./output/unpacked/package/bar.txt'), rfile('./fixtures/to-pack/bar.txt'))
+      assert.equal(rfile('./output/unpacked/package/foo.txt'), rfile('./fixtures/to-pack/foo.txt'))
+      done()
+    }))
+  })
+})
 describe('gziptarball.pipe(unpack(directory, callback))', function () {
   it('unpacks the tarball into the directory', function (done) {
     read(__dirname + '/fixtures/packed.tar.gz').pipe(tar.unpack(__dirname + '/output/unpacked', function (err) {
@@ -57,6 +67,28 @@ describe('pack(directory).pipe(tarball)', function () {
         if (called) return
         called = true
         read(__dirname + '/output/packed.tar.gz').pipe(tar.unpack(__dirname + '/output/unpacked', function (err) {
+          if (err) return done(err)
+          assert.equal(rfile('./output/unpacked/bar.txt'), rfile('./fixtures/to-pack/bar.txt'))
+          assert.equal(rfile('./output/unpacked/foo.txt'), rfile('./fixtures/to-pack/foo.txt'))
+          done()
+        }))
+      })
+  })
+})
+describe('pack(directory, { fromBase: true }).pipe(tarball)', function () {
+  it('packs the directory with input dir as base dir', function (done) {
+    var called = false
+    mkdir(__dirname + '/output/')
+    tar.pack(__dirname + '/fixtures/to-pack', { fromBase: true }).pipe(write(__dirname + '/output/packed.tar.gz'))
+      .on('error', function (err) {
+        if (called) return
+        called = true
+        done(err)
+      })
+      .on('close', function () {
+        if (called) return
+        called = true
+        read(__dirname + '/output/packed.tar.gz').pipe(tar.unpack(__dirname + '/output/unpacked', { strip: 0 }, function (err) {
           if (err) return done(err)
           assert.equal(rfile('./output/unpacked/bar.txt'), rfile('./fixtures/to-pack/bar.txt'))
           assert.equal(rfile('./output/unpacked/foo.txt'), rfile('./fixtures/to-pack/foo.txt'))


### PR DESCRIPTION
Hello

I had an issue using this package with dockerode buildImage command. The problem is that the tarballs created had a subfolder named the folder i sent in. By using fromBase argument to tar.Pack it makes sure that the directory sent in will actually be the root in the tarball and everything works.

There are no breaking changes and the only change i've made is to pass down the option like you do with noProprietary. I didn't write any test for this since you have skipped the test for noProprietary.