### PR TITLE
Switch to caret dependency ranges

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,14 +11,14 @@
   },
   "license": "BSD-2-Clause",
   "dependencies": {
-    "debug": "~2.2.0",
-    "fstream": "~1.0.10",
-    "fstream-ignore": "~1.0.5",
-    "once": "~1.3.3",
-    "readable-stream": "~2.1.4",
-    "rimraf": "~2.5.1",
-    "tar": "~2.2.1",
-    "uid-number": "~0.0.6"
+    "debug": "^2.2.0",
+    "fstream": "^1.0.10",
+    "fstream-ignore": "^1.0.5",
+    "once": "^1.3.3",
+    "readable-stream": "^2.1.4",
+    "rimraf": "^2.5.1",
+    "tar": "^2.2.1",
+    "uid-number": "^0.0.6"
   },
   "devDependencies": {
     "mocha": "*",


### PR DESCRIPTION
Tilde ranges match only patch releases whereas caret ranges match non-breaking minor releases (see npm's [semver guide](https://docs.npmjs.com/misc/semver#tilde-ranges-123-12-1)).

This allows for better npm@3 deduping as new minor versions of dependencies are released.