### PR TITLE
Update debug dependency to fix vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "license": "BSD-2-Clause",
   "dependencies": {
-    "debug": "^2.2.0",
+    "debug": "^2.6.7",
     "fstream": "^1.0.10",
     "fstream-ignore": "^1.0.5",
     "once": "^1.3.3",


### PR DESCRIPTION
There is a vulnerability report via [snyk](https://snyk.io/test/npm/tar-pack/3.3.0
) in this module's dependency, `debug`. 

And it has been resolved above `debug@2.6.7`

references: 
- https://snyk.io/test/npm/tar-pack/3.3.0
- https://github.com/visionmedia/debug/blob/master/CHANGELOG.md#267--2017-05-16