### PR TITLE
chore(package): update debug to version 2.6.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "license": "BSD-2-Clause",
   "dependencies": {
-    "debug": "^2.2.0",
+    "debug": "^2.6.9",
     "fstream": "^1.0.10",
     "fstream-ignore": "^1.0.5",
     "once": "^1.3.3",


### PR DESCRIPTION
This will resolve the REDoS vulnerability detailed at https://nodesecurity.io/advisories/534